### PR TITLE
feat: add scripts to create base (empty) database

### DIFF
--- a/bin/buildBaseDB.bash
+++ b/bin/buildBaseDB.bash
@@ -1,0 +1,129 @@
+#!/bin/bash
+# shellcheck disable=SC1091  # Make sources okay.
+
+SCRIPT_PATH=$(readlink -f "$0")       # Path to this script.
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")  # Path to directory containing this script.
+REPO_DIR=$(dirname "$SCRIPT_DIR")     # Path to the main repo directory      
+
+source "$SCRIPT_DIR/colors.bash"
+source "$SCRIPT_DIR/lib.bash"
+
+# Ensure that this script is being run in the development container.
+HOST=$(docker inspect -f '{{.Name}}' "$HOSTNAME" 2> /dev/null)
+if [ ! "$HOST" == "/fd2_dev" ]; then
+  echo -e "${RED}ERROR:${NO_COLOR} The buildBaseDB.bash script must be run in the fd2dev container."
+  exit 255
+fi
+
+# Ensure that the FarmData2 repository exits
+if [ ! -d "$HOME/FarmData2" ]; then
+  echo -e "${RED}ERROR:${NO_COLOR} The FarmData2 repository must be in /home/fd2dev/FarmData2".
+  exit 255
+fi
+
+echo -e "${UNDERLINE_GREEN}Building the base (empty) database${NO_COLOR}"
+
+# Clearing the drupal cache
+echo "Clearing the drupal cache..."
+docker exec -it fd2_farmos drush cr
+echo "  Cleared."
+
+# Shut down database container
+echo "Stopping the database container..."
+docker stop fd2_postgres > /dev/null
+echo "  Stopped."
+
+# Make sure that the FarmData2/docker/db directory has appropriate permissions.
+echo "Setting permissions on $HOME/FarmData2/docker/db..."
+sudo chmod g+rwx "$HOME/FarmData2/docker/db"
+error_check
+sudo chgrp fd2dev "$HOME/FarmData2/docker/db"
+error_check
+safe_cd "$HOME/FarmData2/docker/db"
+echo "  Set."
+
+# Backup the current database if desired.
+Y_N=""
+while [[ "$Y_N" != "n" && "$Y_N" != "N" ]]; do
+  read -rp "Backup the current database (Y/N)? " Y_N
+  if [[ "$Y_N" == "y" || "$Y_N" == "Y" ]]; then
+    echo "  Backing up the current database..."
+    NOW=$(date +"%m-%d-%y-%H-%M")
+    BACKUP_FILE="$HOME/FarmData2/docker/db.$NOW.tar.gz"
+
+    sudo tar cjvf "$BACKUP_FILE" ./* > /dev/null
+    error_check
+
+    echo "    Current database backed up to $BACKUP_FILE"
+    echo "    Use the following to restore:"
+    echo "      docker stop fd2_postgres"
+    echo "      sudo chmod g+rwx $HOME/FarmData2/docker/db"
+    echo "      cd $HOME/FarmData2/docker/db"
+    echo "      sudo rm -rf ./*"
+    echo "      sudo tar -xjf $BACKUP_FILE"
+    echo "      docker start fd2_postgres"
+
+    break
+  else
+    echo "  Current database not backed up."
+  fi
+done
+
+# Delete the current database.
+echo "Deleting current databae..."
+safe_cd "$HOME/FarmData2/docker/db"
+sudo rm -rf ./*
+error_check
+echo "  Deleted."
+
+# Reset the drupal settigns.php file
+echo "Resetting the drupal settings.php file..."
+docker exec -it fd2_farmos rm /opt/drupal/web/sites/default/settings.php 
+error_check
+docker exec -it fd2_farmos cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/default/settings.php
+error_check
+docker exec -it fd2_farmos chown www-data /opt/drupal/web/sites/default/settings.php 
+error_check
+docker exec -it fd2_farmos chgrp www-data /opt/drupal/web/sites/default/settings.php
+error_check
+sleep 5
+echo "  Reset."
+
+# Bring the database container back up.
+echo "Bringing the database container back up..."
+docker start fd2_postgres > /dev/null
+error_check
+sleep 5
+echo "  Up."
+
+# Doing farmOS Configure Site
+echo "Configuring the farmOS site..."
+safe_cd "$REPO_DIR"
+npx cypress run --spec=bin/farmOS.configBaseDB.cy.js
+error_check
+echo "  Configured." 
+
+# Make sure that the new FarmData2/docker/db directory has appropriate permissions.
+echo "Setting permissions on $HOME/FarmData2/docker/db..."
+sudo chmod g+rwx "$HOME/FarmData2/docker/db"
+error_check
+sudo chgrp fd2dev "$HOME/FarmData2/docker/db"
+error_check
+echo "  Set."
+
+# Compress the sample database into the dist directory
+echo "Compressing base database..."
+safe_cd "$HOME/FarmData2/docker/db"
+DIST_FILE="$REPO_DIR/dist/db.base.tar.gz"
+rm "$DIST_FILE" > /dev/null
+sudo tar czvf "$DIST_FILE" ./* > /dev/null
+error_check
+sudo chown fd2dev "$DIST_FILE"
+error_check
+sudo chgrp fd2dev "$DIST_FILE"
+error_check
+sudo chmod g+w "$DIST_FILE"
+error_check
+echo "  Compressed into $DIST_FILE"
+
+echo -e "${UNDERLINE_GREEN}Base (empty) database has been built.${NO_COLOR}"

--- a/bin/colors.bash
+++ b/bin/colors.bash
@@ -1,0 +1,48 @@
+# A list of color codes that can be used with echo.
+# From: https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
+
+# These variables are used only in files that source this one.
+# So disable the undefined variable rule.
+# shellcheck disable=SC2034
+
+NO_COLOR='\033[0m'
+
+# Text colors
+BLACK='\033[0;30m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+WHITE='\033[0;37m'
+
+# Bold text colors
+BOLD_BLACK='\033[1;30m'
+BOLD_RED='\033[1;31m'
+BOLD_GREEN='\033[1;32m'
+BOLD_YELLOW='\033[1;33m'
+BOLD_BLUE='\033[1;34m'
+BOLD_PURPLE='\033[1;35m'
+BOLD_CYAN='\033[1;36m'
+BOLD_WHITE='\033[1;37m'
+
+# Underline
+UNDERLINE_BLACK='\033[4;30m'
+UNDERLINE_RED='\033[4;31m'
+UNDERLINE_GREEN='\033[4;32m'
+UNDERLINE_ORANGE='\033[4;33m'
+UNDERLINE_BLUE='\033[4;34m'
+UNDERLINE_PURPLE='\033[4;35m'
+UNDERLINE_CYAN='\033[4;36m'
+UNDERLINE_WHITE='\033[4;37m'
+
+# Highlighted background
+ON_BLACK='\033[40m'
+ON_RED='\033[41m'
+ON_GREEN='\033[42m'
+ON_ORANGE='\033[43m'
+ON_BLUE='\033[44m'
+ON_PURPLE='\033[45m'
+ON_CYAN='\033[46m'
+ON_WHITE='\033[47m'

--- a/bin/farmOS.configBaseDB.cy.js
+++ b/bin/farmOS.configBaseDB.cy.js
@@ -1,0 +1,38 @@
+describe('Configure the new farmOS instance.', () => {
+
+  it('Setup Database', () => {
+    cy.visit('http://farmos/core/install.php')
+
+    cy.get('#edit-driver-pgsql').click()
+    cy.get('#edit-pgsql-database').type('farm')
+    cy.get('#edit-pgsql-username').type('farm')
+    cy.get('#edit-pgsql-password').type('farm')
+
+    cy.get('#edit-pgsql--2 > .claro-details__summary').click()
+    cy.get('#edit-pgsql-host').clear().type('db')
+
+    cy.get('#edit-save').click()
+  })
+
+  it('Configure Site', () => {
+    cy.visit('http://farmos/core/install.php')
+
+    cy.get('#edit-site-name').type('test farm')
+    cy.get('#edit-site-mail').type('test@no.such.farm.org')
+    cy.get('#edit-account-name').type('admin')
+    cy.get('#edit-account-pass-pass1').type('admin')
+    cy.get('#edit-account-pass-pass2').type('admin')
+    cy.get('#edit-site-default-country').select('United States')
+    cy.get('#edit-enable-update-status-emails').click()
+    cy.get('#edit-submit').click()
+  })
+
+  it('Enable Modules', () => {
+    cy.visit('http://farmos/core/install.php')
+
+    cy.get('#edit-submit').click()
+
+    // Wait a good long time here for the modules to install.
+    cy.get('.page-title', {timeout: 5*60000}).should('have.text', 'Dashboard')
+  })
+})

--- a/bin/lib.bash
+++ b/bin/lib.bash
@@ -1,0 +1,18 @@
+# Checks if prior operation succeeded and terminates if not.
+# Used throughout to avoid continuing if an operation fails.
+function error_check {
+  if [ "$?" != "0" ]; then
+    echo "** Terminating: Error in previous command."
+    exit 255
+  fi
+}
+
+# Do a cd with error handling for a directory that is missing but
+# should be present.
+function safe_cd {
+  cd "$1" 2> /dev/null || (
+    echo -e "${ON_RED}ERROR:${NO_COLOR} Directory $1 is missing."
+    echo -e "Restore this directory and try again."
+    exit 255
+  ) || exit 255
+}


### PR DESCRIPTION
Add scripts in `/bin` that create an empty farmOS database on top of which the full sample database(s) will be built.