### PR TITLE
feat: adds CORS origins to farm client and added tray size vocabulary

### DIFF
--- a/src/sampleDB/addConsumerCORSOrigins.cy.js
+++ b/src/sampleDB/addConsumerCORSOrigins.cy.js
@@ -1,0 +1,46 @@
+describe("Add CORS origins to the farm consumer", () => {
+  it("Add CORS origins", () => {
+    cy.login("admin", "admin");
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );
+    cy.get("#edit-allowed-origins-0-value").clear();
+    cy.get("#edit-allowed-origins-0-value").type("http://localhost:5173");
+    cy.get("#edit-submit").click();
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );
+
+    cy.get("#edit-allowed-origins-1-value").clear();
+    cy.get("#edit-allowed-origins-1-value").type("http://localhost:5174");
+    cy.get("#edit-submit").click();
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );
+
+    cy.get("#edit-allowed-origins-2-value").clear();
+    cy.get("#edit-allowed-origins-2-value").type("http://localhost:5175");
+    cy.get("#edit-submit").click();
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );    
+    
+    cy.get("#edit-allowed-origins-3-value").clear();
+    cy.get("#edit-allowed-origins-3-value").type("http://localhost:4173");
+    cy.get("#edit-submit").click();
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );
+
+    cy.get("#edit-allowed-origins-4-value").clear();
+    cy.get("#edit-allowed-origins-4-value").type("http://localhost:4174");
+    cy.get("#edit-submit").click();
+    cy.visit(
+      "admin/config/services/consumer/2/edit?destination=/admin/config/services/consumer"
+    );
+
+    cy.get("#edit-allowed-origins-5-value").clear();
+    cy.get("#edit-allowed-origins-5-value").type("http://localhost:4175");
+    cy.get("#edit-submit").click();
+  });
+});

--- a/src/sampleDB/addTraySizes.js
+++ b/src/sampleDB/addTraySizes.js
@@ -1,0 +1,65 @@
+import { processCsvFile } from "../util/csvUtil.js";
+import * as farmosUtil from "../util/farmosUtil.js";
+
+import { basename, dirname } from "path";
+import { fileURLToPath } from "url";
+
+/*
+ * Set the name of the CSV file to be processed and the
+ * messages to be printed before and after processing here.
+ * The CSV file is assumed to be in the sampleData directory.
+ */
+const csv_file = "traySizes.csv";
+const startMsg = "Adding tray sizes from " + csv_file + "...";
+const endMsg = "Tray sizes added.";
+
+/*
+ * Setup the information for connecting to the farmOS instance
+ * in the FarmData2 development environment.  Note: URL cannot
+ * have a trailing /.
+ */
+const URL = "http://farmos";
+const client = "farm";
+const user = "admin";
+const pass = "admin";
+
+/*
+ * Get a fully initialized and logged in instance of the farmOS.js
+ * farmOS object that will be used to write assets, logs, etc.
+ */
+const farm = await farmosUtil.getFarmOSInstance(URL, client, user, pass);
+
+/*
+ * Kick off the the pipeline that reads the csv file and passes
+ * each row of data from the file to the processRow function.
+ */
+const data_file = (dirname(fileURLToPath(import.meta.url))) + "/sampleData/" + csv_file;
+processCsvFile(data_file, processRow, startMsg, endMsg);
+
+/*
+ * Implement this function to processes each row of the CSV file.
+ * The contents of the row arrive as an array with each entry being
+ * a column from the line of the CSV file.
+ */
+async function processRow(row) {
+
+      console.log("  Adding tray size " + row[0] + "...");
+
+      const traySize = farm.term.create({
+        type: "taxonomy_term--tray_size",
+        attributes: {
+          name: row[0],
+          description: row[1],
+        },
+      });
+
+      try {
+        const result = await farm.term.send(traySize);
+      } catch (e) {
+        console.log("API error sending tray size " + row[0]);
+        console.log(e);
+        process.exit(1);
+      }
+
+      console.log("  Added.");
+}

--- a/src/sampleDB/buildSampleDB.bash
+++ b/src/sampleDB/buildSampleDB.bash
@@ -30,6 +30,15 @@ echo ""
 error_check
 echo ""
 
+# Add the Allowed CORS origins to the farm consumer.
+echo "Adding CORS origins..."
+CUR_DIR=$(pwd)
+safe_cd "$REPO_DIR"
+npx cypress run --spec=src/sampleDB/addConsumerCORSOrigins.cy.js
+error_check 
+safe_cd "$CUR_DIR"
+echo "Added."
+
 # Add the users and assign their roles
 "$SCRIPT_DIR/addUsers.bash"
 error_check
@@ -45,17 +54,18 @@ node "$SCRIPT_DIR/addCrops.js"
 error_check
 echo ""
 
+# Add the seeding tray sizes
+node "$SCRIPT_DIR/addTraySizes.js"
+error_check
+echo ""
+
+
 # Delete the authentication token if it exists.
 # Necessary because base DB was reinstalled so old token is not valid. 
 echo "Deleting locally cached authentication token..."
 rm -rf "$SCRIPT_DIR/scratch"
 echo "Deleted."
 echo ""
-
-
-
-
-
 
 # Make sure that the new FarmData2/docker/db directory has appropriate permissions.
 echo "Setting permissions on $HOME/FarmData2/docker/db..."

--- a/src/sampleDB/sampleData/traySizes.csv
+++ b/src/sampleDB/sampleData/traySizes.csv
@@ -1,0 +1,18 @@
+# Sample Data for the seeding tray sizes
+#
+# Format:
+#
+# Each line represents a tray size with the following comma delimited information:
+#   size,description
+#
+# Anything following a # on a line is a considered a comment.
+# Thus, names and descriptions cannot contain #
+# Blank Lines are ignored.
+#
+# Tray sizes are created as taxonomy_term--tray_sizes terms.
+50,50 cell tray
+72,72 cell tray
+96,96 cell tray
+128,128 cell tray
+200,200 cell tray
+288,288 cell tray

--- a/src/util/printFarmosLogs.js
+++ b/src/util/printFarmosLogs.js
@@ -26,7 +26,7 @@ const logTypes = [
   "taxonomy_term--animal_type", "taxonomy_term--material_type",
   "taxonomy_term--season", "taxonomy_term--log_category",
   "taxonomy_term--crop_family", "taxonomy_term--unit", 
-  "taxonomy_term--plant_type",
+  "taxonomy_term--plant_type", "taxonomy_term--tray_size",
   "user--user"
 ]
 


### PR DESCRIPTION
Adds CORS origins to the `farm` client so that test servers can access the API.

Also adds the `tray_size` vocabulary and populates it with a few common tray seeding tray sizes.

Closes #11 