### PR TITLE
feat: enables the farmOS inventory module

### DIFF
--- a/src/sampleDB/enableFarmData2Modules.bash
+++ b/src/sampleDB/enableFarmData2Modules.bash
@@ -8,6 +8,11 @@ source "$REPO_DIR/bin/preflight.bash"
 
 echo "Enabling FarmData2 modules..."
 
+echo "  Enabling the farmOS Inventory Module..."
+docker exec -it fd2_farmos drush en farm_inventory -y
+error_check
+echo "  Enabled."
+
 echo "  Enabling farm_fd2..."
 docker exec -it fd2_farmos drush en farm_fd2 -y
 error_check
@@ -22,5 +27,10 @@ echo "  Enabling farm_fd2_school..."
 docker exec -it fd2_farmos drush en farm_fd2_school -y
 error_check
 echo "    Enabled."
+
+echo "  Clearing Drupal cache..."
+clearDrupalCache.bash
+error_check
+echo "  Cleared."
 
 echo "FarmData2 modules enabled."


### PR DESCRIPTION
FarmData2 uses the farmOS inventory module to track the inventory of assets (e.g. the number of trays available for transplant, or the number of row/feet available for harvest, etc). To do so, the inventory module must be enabled.  This module is not enabled by default, so this PR enables it when the sample database is built.