### PR TITLE
fix: makes units for tray seedings consistent

### DIFF
--- a/src/sampleDB/sampleData/units.csv
+++ b/src/sampleDB/sampleData/units.csv
@@ -22,6 +22,7 @@
 Count,Parent term for units that are counts.
 #,BEDS
 #,BUNCH
+,CELLS,A number of seeding tray cells.
 #,EACH
 #,EAR
 #,FLATS
@@ -49,7 +50,7 @@ Count,Parent term for units that are counts.
 #Rate
 #Rating
 Ratio,Parent term for units that are ratios.
-,CELLS/TRAY,The number of cells in a tray.
-#,CELLS/FLAT
+,CELLS/TRAY,The number of cells in a seeding tray.
 #,ROWS/BED
+,SEEDS/CELL,The number of seeds per cell in a seeding tray.
 #Probability


### PR DESCRIPTION
Cleans up the units that are used in tray seeding so that they are consistent across measures.

There are now units: 
- `TRAYS`, 'CELLS`, `SEEDS` for `count` `measure`.
- `CELLS/TRAY`, `SEEDS/CELL` for `ratio` `measure`.