### PR TITLE
feat: adds generic equipment for seedings to sample database

### DIFF
--- a/src/sampleDB/addEquipment.js
+++ b/src/sampleDB/addEquipment.js
@@ -64,7 +64,7 @@ async function processRow(row) {
       type: "asset--equipment",
       attributes: {
         name: row[0],
-        description: row[1],
+        notes: row[1],
       },
     });
 
@@ -88,7 +88,7 @@ async function processRow(row) {
         name: row[1],
         manufacturer: row[2],
         model: row[3],
-        description: row[4],
+        notes: row[4],
       },
     });
     equipment.relationships.parent.push({

--- a/src/sampleDB/addEquipment.js
+++ b/src/sampleDB/addEquipment.js
@@ -1,0 +1,112 @@
+import { processCsvFile } from "../library/cvsUtil/csvUtil.js";
+import * as farmosUtil from "../library/farmosUtil/farmosUtil.js";
+
+import { basename, dirname } from "path";
+import { fileURLToPath } from "url";
+import { LocalStorage } from 'node-localstorage';
+
+/*
+ * Set the name of the CSV file to be processed and the
+ * messages to be printed before and after processing here.
+ * The CSV file is assumed to be in the sampleData directory.
+ */
+const csv_file = "equipment.csv";
+const startMsg = "Adding equipment from " + csv_file + "...";
+const endMsg = "Equipment added.";
+
+/*
+ * Setup the information for connecting to the farmOS instance
+ * in the FarmData2 development environment.  Note: URL cannot
+ * have a trailing /.
+ */
+const URL = "http://farmos";
+const client = "farm";
+const user = "admin";
+const pass = "admin";
+
+/*
+ * Get a local storage object that we'll use to simulate the
+ * browser's localStorage and sessionStorage when running in node.
+ */
+let ls = new LocalStorage('scratch');
+
+/*
+ * Get a fully initialized and logged in instance of the farmOS.js
+ * farmOS object that will be used to write assets, logs, etc.
+ */
+const farm = await farmosUtil.getFarmOSInstance(URL, client, user, pass, ls);
+
+/*
+ * Get any farmos id maps that we need for processing the data.
+ */
+//const usernameMap = await farmosUtil.getUsernameToUserMap(farm);
+
+/*
+ * Kick off the the pipeline that reads the csv file and passes
+ * each row of data from the file to the processRow function.
+ */
+const data_file =
+  dirname(fileURLToPath(import.meta.url)) + "/sampleData/" + csv_file;
+processCsvFile(data_file, processRow, startMsg, endMsg);
+
+let categoryId = null;
+let categoryName = null;
+
+/*
+ * Implement this function to processes each row of the CSV file.
+ * The contents of the row arrive as an array with each entry being
+ * a column from the line of the CSV file.
+ */
+async function processRow(row) {
+  if (row[0] != "") {
+    console.log("  Adding equipment category " + row[0] + "...");
+    const category = farm.asset.create({
+      type: "asset--equipment",
+      attributes: {
+        name: row[0],
+        description: row[1],
+      },
+    });
+
+    try {
+      const result = await farm.asset.send(category);
+      categoryId = result.id;
+      categoryName = row[0];
+    } catch (e) {
+      console.log("API error sending measure " + row[0]);
+      console.log(e);
+      process.exit(1);
+    }
+    console.log("  Added.");
+  } else if (row[1] != "") {
+    console.log(
+      "  Adding equipment " + row[1] + " to category " + categoryName + "..."
+    );
+    const equipment = farm.asset.create({
+      type: "asset--equipment",
+      attributes: {
+        name: row[1],
+        manufacturer: row[2],
+        model: row[3],
+        description: row[4],
+      },
+    });
+    equipment.relationships.parent.push({
+      type: "asset--equipment",
+      id: categoryId,
+    });
+
+    try {
+      const result = await farm.asset.send(equipment);
+    } catch (e) {
+      console.log("API error sending unit " + row[1]);
+      console.log(e);
+      process.exit(1);
+    }
+    console.log("  Added.");
+  } else {
+    console.log("Invalid data in " + csv_file + ".");
+    console.log(row);
+    process.exit(1);
+  }
+}

--- a/src/sampleDB/buildSampleDB.bash
+++ b/src/sampleDB/buildSampleDB.bash
@@ -70,6 +70,11 @@ node "$SCRIPT_DIR/addLogCategories.js"
 error_check
 echo ""
 
+# Add the equipment
+node "$SCRIPT_DIR/addEquipment.js"
+error_check
+echo ""
+
 # Delete the authentication token if it exists.
 # Necessary because base DB was reinstalled so old token is not valid. 
 echo "Deleting locally cached authentication token..."

--- a/src/sampleDB/sampleData/equipment.csv
+++ b/src/sampleDB/sampleData/equipment.csv
@@ -1,0 +1,34 @@
+# Sample Data for the equipment assets
+#
+# Format:
+#
+# Each line represents either a category of equipment or 
+# any equipment asset.
+#
+# Equipment categories have the format:
+#   category name,category description.
+#
+# Equipment within a category are listed immediately following its category
+# and have the following comma delimited information:
+#   ,name,manufacturer,model,description
+#
+# Anything following a # on a line is a considered a comment.
+# Thus, names and descriptions cannot contain #
+# Blank Lines are ignored.
+
+General,Equipment used for a variety of operations.
+,Tractor,Company G,468,A standard tractor.
+,Small Tractor,Company I,987,A compact tractor.
+#Tillage,Equipment used exclusively for tillage.
+#,Bed Shaper,Company A,123,A bed shaper.
+#,Chisel Plow,Company B,234,A chisel plow.
+#,Rotary Cultivator,Company C,456,A rotary cultivator.
+#,Disk,Company D,789,A disc cultivator.
+#,Harrow,Company E,135,A harrow.
+Seeding,Equipment used exclusively for Seeding.
+,Tow Behind Broadcaster,Company J,876,A broadcast seed spreader.
+,Portable Broadcaster,Company K, 765,A chest mounted portable seed spreader.
+,Planter,Company F,357,A planter.
+,Seeding Drill,Company E,246,A seeding drill.
+#Spraying,Equipment used exclusively for spraying.
+#,Sprayer,Company H,379,A sprayer.

--- a/src/sampleDB/sampleData/units.csv
+++ b/src/sampleDB/sampleData/units.csv
@@ -32,8 +32,9 @@ Count,Parent term for units that are counts.
 #,PIECE
 ,SEEDS,A number of seeds.
 ,TRAYS,A number of seeding trays.
-#Length/depth
-#,ROW FEET
+Length/depth
+,FEET,A number of feet.
+,INCHES,A number of inches.
 #Weight
 #,POUND
 #Area
@@ -47,10 +48,11 @@ Count,Parent term for units that are counts.
 #Pressure
 #Water Content
 #Value
-#Rate
+Rate,Parent term for units that are rates.
+,MPH,A speed in miles per hour.
 #Rating
 Ratio,Parent term for units that are ratios.
 ,CELLS/TRAY,The number of cells in a seeding tray.
-#,ROWS/BED
+,ROWS/BED,The number of rows in a bed.
 ,SEEDS/CELL,The number of seeds per cell in a seeding tray.
 #Probability


### PR DESCRIPTION
This PR:
- Adds processing for a list of equipment assets to be added to the sample database for farmOS.
- Includes in that list:
  - Generic equipment that can be used for a variety of tasks (e.g. Tractor)
  - Equipment specifically for seeding events (e.g. Seeding Drill).
- A few tweaks to the list of Units being added just because they happened at the same time.

Note: This equipment list is sufficient to begin work and testing of the direct seeding features. But it was just made up by me and should be revised in discussion with Matt.