### PR TITLE
feat: add log category for soil disturbances

### DIFF
--- a/src/sampleDB/sampleData/logCategories.csv
+++ b/src/sampleDB/sampleData/logCategories.csv
@@ -13,3 +13,5 @@
 seeding_cover_crop,For seeding logs representing seedings of cover crops.
 seeding_direct,For seeding logs representing seedings directly in the ground.
 seeding_tray,For seeding logs representing seedings in trays.
+
+activity_soil_disturbance_tillage,For activity logs representing tillage soil disturbances.


### PR DESCRIPTION
Adds a log category of `activity_soil_disturbance_tillage` to be used to indicate activity logs that represent soil disturbances as a result of tillage.