### PR TITLE
fix: adds a greenhouse with no beds

### DIFF
--- a/src/sampleDB/sampleData/areas.csv
+++ b/src/sampleDB/sampleData/areas.csv
@@ -41,3 +41,4 @@ GHANA,greenhouse,The GHANA Greenhouse
 ,GHANA-2,bed,Bed GHANA-2 in GHANA Greenhouse
 ,GHANA-3,bed,Bed GHANA-3 in GHANA Greenhouse
 ,GHANA-4,bed,Bed GHANA-4 in GHANA Greenhouse
+JASMINE,greenhouse,The JASMINE Greenhouse


### PR DESCRIPTION
Need a greenhouse with no beds to test modifications to the `LocationSelector` component that allows for the option to include only greenhouses with beds in the list of locations.  Prior to this PR, all of the Greenhouses contained beds.