### PR TITLE
chore: adds script to link libraries from FarmData2

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -1,3 +1,4 @@
+backmerged
 bashlint
 Braught
 chgrp
@@ -17,6 +18,7 @@ novnc
 pgid
 pinia
 preprocess
+printlog
 rushstack
 setsid
 shellcheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules
 scratch
 docs
-library/farmosUtil
+src/library/farmosUtil
+src/library/tray_seeding
+src/library/direct_seeding
+

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -11,6 +11,7 @@ const config = {
         "preset": "angular",
         "releaseRules": [
           { "type": "build", "release": false },
+          { "type": "chore", "release": false },
           { "type": "ci", "release": false },
           { "type": "docs", "release": false },
           { "type": "perf", "release": false },

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Install the dependencies by:
 - Change into the `FD2-SampleDBs` directory
 - run `npm install`
 
-Link to the `FarmData2/library/farmosUtil` directory:
-  - The following commands assume that `FarmData2` and `FD2-SampleDBs` are cloned in the user's home directory.  Please adjust accordingly.
-  - `cd ~/FD2-SampleDBs/library`
-  - `ln -s ~/FarmData2/library/farmosUtil farmosUtil`
+Ensure that the FarmData2 repository has also been cloned.
+- `git clone https://github.com/FarmData2/FarmData2.git`
+
+Create the links to the useful libraries in the FarmData2 repository:
+- Change into the `FD2-SampleDBs` directory
+- `bin/linkFD2Libs.bash`
 
 ## Building the Databases
 
@@ -36,9 +38,13 @@ The structure of a farmOS record (e.g. asset, log, quantity, term, user) can be 
 
 where `<type>` is one of the record types.  Run the command without the `<type` argument to see a list of all of the record types.
 
-### farmosUtil.js
+### FarmData2 Libraries
 
-The `src/library/farmosUtil/` is a symlink to the `FarmData2/library/farmosUtil` module that provides useful utility functions for working with farmOS records.  These functions should be maintained and updated from the `FarmData2` repo.
+The `linkFD2libs.bash` command will ensure that the libraries from FarmData2 that are used are linked into this repository.  A symlink for each linked library is created in the `src/libraries` directory.
+
+When new a library is added to FarmData2 that are needed here the `linkFD2libs.bash` and `.gitignore` files should be updated so that the new library is linked.
+
+The libraries should be maintained only from the FarmData2 repository.  They should not be modified via the `src/libraries` in this project.
 
 ### Development Workflow
 

--- a/bin/linkFD2Libs.bash
+++ b/bin/linkFD2Libs.bash
@@ -1,0 +1,42 @@
+# Create sym links to the libraries in FarmData2
+# that are used to create the sample databases.
+
+# shellcheck disable=SC1091  # Make sources okay.
+
+REPO_DIR=$(git rev-parse --show-toplevel)     
+source "$REPO_DIR/bin/lib.bash"
+
+FD2_DIR="$HOME/FarmData2"
+
+echo "Linking FarmData2 libraries..."
+
+echo "  Checking for FarmData2 directory..."
+while [ ! -d $FD2_DIR ];
+do
+  echo "    Directory $FD2_DIR not found."
+  read -r -p "    Enter path to FarmData2: " FD2_DIR
+done
+echo "    Using FarmData2 directory at: $FD2_DIR"
+
+safe_cd "$REPO_DIR/src/library"
+
+LINKS=(
+  'library/farmosUtil' 
+  'modules/farm_fd2/src/entrypoints/tray_seeding'
+  'modules/farm_fd2/src/entrypoints/direct_seeding'
+)
+
+for LINK in "${LINKS[@]}";
+do
+  echo "  Linking $LINK in $PWD..."
+  LINK_NAME="$(basename $LINK)"
+  rm -f "$LINK_NAME"
+  error_check "    Unable to remove existing $LINK_NAME link." 
+  ln -s "$FD2_DIR/$LINK" "$LINK_NAME"
+  error_check "    Unable to create $LINK_NAME link to $FD2_DIR/$LINK."
+  echo "  Linked."
+done
+
+
+
+

--- a/src/library/farmosUtil
+++ b/src/library/farmosUtil
@@ -1,1 +1,0 @@
-/home/fd2dev/FarmData2/library/farmosUtil/


### PR DESCRIPTION
The creation of the databases uses libraries from the FarmData2 project.  This PR adds a script that when run will create the necessary links to those libraries so that they can be used in the scripts that create the sample databases.