### PR TITLE
fix: adds tray seeding for testing crop names endpoint

### DIFF
--- a/src/sampleDB/addTraySeedings.js
+++ b/src/sampleDB/addTraySeedings.js
@@ -67,7 +67,7 @@ async function processRow(row) {
   };
 
   console.log(
-    "  Adding tray seeding log on " +
+    "  Adding tray seeding on " +
       form.seedingDate +
       " for " +
       form.cropName +

--- a/src/sampleDB/sampleData/traySeedings.csv
+++ b/src/sampleDB/sampleData/traySeedings.csv
@@ -51,3 +51,4 @@
 "2019-07-05","LETTUCE-ICEBERG","CHUAU","0","128","1","No trays for testing."
 "2019-06-20","LETTUCE-ICEBERG","JASMINE","0","128","1","No trays for testing."
 "2019-08-07","LETTUCE-ICEBERG","GHANA","0","128","1","No trays for testing."
+"2019-04-09","BEAN-FAVA","GHANA","0","50","1","No trays for testing."


### PR DESCRIPTION
Adds a tray seeding for `BEAN-FAVA` with 0 trays.  This is the only seeding for `BEAN-FAVA` so this allows us to test that the name `BEAN-FAVA` does not appear in the crop list for the list of crops that can be transplanted.